### PR TITLE
Update dependencies: Python, Django, Celery, and Kombu

### DIFF
--- a/{{ cookiecutter.project_name }}/webapp/Dockerfile
+++ b/{{ cookiecutter.project_name }}/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.3-slim-bullseye
+FROM python:3.11.4-slim-bullseye
 
 ARG USER_ID
 ARG GROUP_ID

--- a/{{ cookiecutter.project_name }}/webapp/pdm.lock
+++ b/{{ cookiecutter.project_name }}/webapp/pdm.lock
@@ -24,7 +24,8 @@ summary = "Timeout context manager for asyncio programs"
 
 [[package]]
 name = "billiard"
-version = "3.6.4.0"
+version = "4.1.0"
+requires_python = ">=3.7"
 summary = "Python multiprocessing fork with improvements and bugfixes"
 
 [[package]]
@@ -42,17 +43,18 @@ dependencies = [
 
 [[package]]
 name = "celery"
-version = "5.2.7"
+version = "5.3.0"
 requires_python = ">=3.7"
 summary = "Distributed Task Queue."
 dependencies = [
-    "billiard<4.0,>=3.6.4.0",
-    "click-didyoumean>=0.0.3",
+    "billiard<5.0,>=4.1.0",
+    "click-didyoumean>=0.3.0",
     "click-plugins>=1.1.1",
     "click-repl>=0.2.0",
-    "click<9.0,>=8.0.3",
-    "kombu<6.0,>=5.2.3",
-    "pytz>=2021.3",
+    "click<9.0,>=8.1.2",
+    "kombu<6.0,>=5.3.0",
+    "python-dateutil>=2.8.2",
+    "tzdata>=2022.7",
     "vine<6.0,>=5.0.0",
 ]
 
@@ -121,7 +123,7 @@ summary = "A Python library that converts cron expressions into human readable s
 
 [[package]]
 name = "django"
-version = "4.2.1"
+version = "4.2.2"
 requires_python = ">=3.8"
 summary = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 dependencies = [
@@ -169,11 +171,11 @@ summary = "brain-dead simple config-ini parsing"
 
 [[package]]
 name = "kombu"
-version = "5.2.4"
-requires_python = ">=3.7"
+version = "5.3.0"
+requires_python = ">=3.8"
 summary = "Messaging library for Python."
 dependencies = [
-    "amqp<6.0.0,>=5.0.9",
+    "amqp<6.0.0,>=5.1.1",
     "vine",
 ]
 
@@ -207,7 +209,7 @@ summary = "Utility library for gitignore style pattern matching of file paths."
 
 [[package]]
 name = "platformdirs"
-version = "3.5.1"
+version = "3.5.2"
 requires_python = ">=3.7"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 
@@ -330,7 +332,7 @@ summary = "Measures the displayed width of unicode strings in a terminal"
 lock_version = "4.2"
 cross_platform = true
 groups = ["default", "dev"]
-content_hash = "sha256:326d0368516074dc89db7c48d549a2475dc81fa14fc71ed2128e72f610232493"
+content_hash = "sha256:41574c81016242320407332005f27f0b3a510876f475fec8f6acfbbac6fba20f"
 
 [metadata.files]
 "amqp 5.1.1" = [
@@ -345,9 +347,9 @@ content_hash = "sha256:326d0368516074dc89db7c48d549a2475dc81fa14fc71ed2128e72f61
     {url = "https://files.pythonhosted.org/packages/54/6e/9678f7b2993537452710ffb1750c62d2c26df438aa621ad5fa9d1507a43a/async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
     {url = "https://files.pythonhosted.org/packages/d6/c1/8991e7c5385b897b8c020cdaad718c5b087a6626d1d11a23e1ea87e325a7/async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
 ]
-"billiard 3.6.4.0" = [
-    {url = "https://files.pythonhosted.org/packages/2b/89/0c43de91d4e52eaa7bd748771d417f6ac9e51e66b2f61928c2151bf65878/billiard-3.6.4.0-py3-none-any.whl", hash = "sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b"},
-    {url = "https://files.pythonhosted.org/packages/92/91/40de1901da8ec9eeb7c6a22143ba5d55d8aaa790761ca31342cedcd5c793/billiard-3.6.4.0.tar.gz", hash = "sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547"},
+"billiard 4.1.0" = [
+    {url = "https://files.pythonhosted.org/packages/b3/9c/c02d3988ddb0e32e974db1d8434616f1503b12fc7087bf18243ccd69a60a/billiard-4.1.0.tar.gz", hash = "sha256:1ad2eeae8e28053d729ba3373d34d9d6e210f6e4d8bf0a9c64f92bd053f1edf5"},
+    {url = "https://files.pythonhosted.org/packages/e3/a4/ae83eeb0563804a4148ff0e52f530e675bc90718c7c770cdfe4af1340c86/billiard-4.1.0-py3-none-any.whl", hash = "sha256:0f50d6be051c6b2b75bfbc8bfd85af195c5739c281d3f5b86a5640c65563614a"},
 ]
 "black 23.3.0" = [
     {url = "https://files.pythonhosted.org/packages/06/1e/273d610249f0335afb1ddb03664a03223f4826e3d1a95170a0142cb19fb4/black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
@@ -376,9 +378,9 @@ content_hash = "sha256:326d0368516074dc89db7c48d549a2475dc81fa14fc71ed2128e72f61
     {url = "https://files.pythonhosted.org/packages/eb/a5/17b40bfd9b607b69fa726b0b3a473d14b093dcd5191ea1a1dd664eccfee3/black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
     {url = "https://files.pythonhosted.org/packages/fd/5b/fc2d7922c1a6bb49458d424b5be71d251f2d0dc97be9534e35d171bdc653/black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
 ]
-"celery 5.2.7" = [
-    {url = "https://files.pythonhosted.org/packages/1d/99/21fe9d1829cab4fc77d18f89d0c4cbcfe754e95f8b8f4af64fe4997c442f/celery-5.2.7-py3-none-any.whl", hash = "sha256:138420c020cd58d6707e6257b6beda91fd39af7afde5d36c6334d175302c0e14"},
-    {url = "https://files.pythonhosted.org/packages/ce/21/41a0028f6d610987c0839250357c1a00f351790b8a448c2eb323caa719ac/celery-5.2.7.tar.gz", hash = "sha256:fafbd82934d30f8a004f81e8f7a062e31413a23d444be8ee3326553915958c6d"},
+"celery 5.3.0" = [
+    {url = "https://files.pythonhosted.org/packages/6b/4c/b06523d8ab2d6d9a812e3b9dd5a8a3b01d7590da842da4c4a9d9af7c2df3/celery-5.3.0.tar.gz", hash = "sha256:1eaba5ee14d8c8c0bed8f6063e5e10dabdbcf23503a861cf0e10b7221d99cb0d"},
+    {url = "https://files.pythonhosted.org/packages/b8/b1/fb24a605e7f2fe654bb0b63985bb0c95b1bb5d5ffbfaf46134c92eb93f61/celery-5.3.0-py3-none-any.whl", hash = "sha256:95d29f9a93f41c4b122fddf1fe3ef13f872029dca4ad1f9af4f1a414442ceecf"},
 ]
 "click 8.1.3" = [
     {url = "https://files.pythonhosted.org/packages/59/87/84326af34517fca8c58418d148f2403df25303e02736832403587318e9e8/click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -465,9 +467,9 @@ content_hash = "sha256:326d0368516074dc89db7c48d549a2475dc81fa14fc71ed2128e72f61
 "cron-descriptor 1.4.0" = [
     {url = "https://files.pythonhosted.org/packages/24/a0/455f5a0181cf9a0d2e84d3a66c88de019dce5644ad9680825d1c8a403335/cron_descriptor-1.4.0.tar.gz", hash = "sha256:b6ff4e3a988d7ca04a4ab150248e9f166fb7a5c828a85090e75bcc25aa93b4dd"},
 ]
-"django 4.2.1" = [
-    {url = "https://files.pythonhosted.org/packages/12/13/78e8622180f101e95297965045ff1325ea7301c1b80f756debbeaa84c3be/Django-4.2.1-py3-none-any.whl", hash = "sha256:066b6debb5ac335458d2a713ed995570536c8b59a580005acb0732378d5eb1ee"},
-    {url = "https://files.pythonhosted.org/packages/89/76/23ee9b9d2bd4119e930eb19164732b79c0a4f6259ca198209b0fe36551ea/Django-4.2.1.tar.gz", hash = "sha256:7efa6b1f781a6119a10ac94b4794ded90db8accbe7802281cd26f8664ffed59c"},
+"django 4.2.2" = [
+    {url = "https://files.pythonhosted.org/packages/5c/fa/427fbcac5633f4b88fda7953efb04db903ca7e6d9486afdbda525c4006cc/Django-4.2.2.tar.gz", hash = "sha256:2a6b6fbff5b59dd07bef10bcb019bee2ea97a30b2a656d51346596724324badf"},
+    {url = "https://files.pythonhosted.org/packages/ba/f3/7a66888bda4017198a692887bd566123732783073c1fd424db15358525fd/Django-4.2.2-py3-none-any.whl", hash = "sha256:672b3fa81e1f853bb58be1b51754108ab4ffa12a77c06db86aa8df9ed0c46fe5"},
 ]
 "django-celery-beat 2.5.0" = [
     {url = "https://files.pythonhosted.org/packages/0b/97/ca63898f76dd43fc91f4791b05dbbecb60dc99215f16b270e9b1e29af974/django-celery-beat-2.5.0.tar.gz", hash = "sha256:cd0a47f5958402f51ac0c715bc942ae33d7b50b4e48cba91bc3f2712be505df1"},
@@ -485,9 +487,9 @@ content_hash = "sha256:326d0368516074dc89db7c48d549a2475dc81fa14fc71ed2128e72f61
     {url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
     {url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
 ]
-"kombu 5.2.4" = [
-    {url = "https://files.pythonhosted.org/packages/d9/f3/62d12dd7ebad710319f0877c1c33bca379fc7d28069daae890fa2fa444c8/kombu-5.2.4-py3-none-any.whl", hash = "sha256:8b213b24293d3417bcf0d2f5537b7f756079e3ea232a8386dcc89a59fd2361a4"},
-    {url = "https://files.pythonhosted.org/packages/e1/9e/3811be7d86ac3be6d1a1f5098f95b1d8e2519c12c537719c7e13c8a12800/kombu-5.2.4.tar.gz", hash = "sha256:37cee3ee725f94ea8bb173eaab7c1760203ea53bbebae226328600f9d2799610"},
+"kombu 5.3.0" = [
+    {url = "https://files.pythonhosted.org/packages/7d/a4/09517596299ee8b7f27e39ac0867949bd2f6f6025aa02fcdc17a2c2a5885/kombu-5.3.0-py3-none-any.whl", hash = "sha256:fa9be55281bb351ba9da582b2a74e3dd5015b8d075b287e4d16f0b2f25fefcc2"},
+    {url = "https://files.pythonhosted.org/packages/8c/04/4adf5f7bdb2f00c20f09afca1ab0e9899c26f236dea3eb8354d61aa7ae02/kombu-5.3.0.tar.gz", hash = "sha256:d084ec1f96f7a7c37ba9e816823bdbc08f0fc7ddb3a5be555805e692102297d8"},
 ]
 "mypy 1.3.0" = [
     {url = "https://files.pythonhosted.org/packages/09/7b/8eb0d648352c61b08cb364d278b5c12c3f1c5841724fdd2929d7172b7eaf/mypy-1.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f9dca1e257d4cc129517779226753dbefb4f2266c4eaad610fc15c6a7e14283e"},
@@ -529,9 +531,9 @@ content_hash = "sha256:326d0368516074dc89db7c48d549a2475dc81fa14fc71ed2128e72f61
     {url = "https://files.pythonhosted.org/packages/95/60/d93628975242cc515ab2b8f5b2fc831d8be2eff32f5a1be4776d49305d13/pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
     {url = "https://files.pythonhosted.org/packages/be/c8/551a803a6ebb174ec1c124e68b449b98a0961f0b737def601e3c1fbb4cfd/pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
 ]
-"platformdirs 3.5.1" = [
-    {url = "https://files.pythonhosted.org/packages/89/7e/c6ff9ddcf93b9b36c90d88111c4db354afab7f9a58c7ac3257fa717f1268/platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
-    {url = "https://files.pythonhosted.org/packages/9c/0e/ae9ef1049d4b5697e79250c4b2e72796e4152228e67733389868229c92bb/platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
+"platformdirs 3.5.2" = [
+    {url = "https://files.pythonhosted.org/packages/0e/e4/69bff18235f446e5c7ad4139321a60f3f5b5a5edd5a41d2364b4278a6f38/platformdirs-3.5.2.tar.gz", hash = "sha256:f56f8067f85988d619f174a3c9dbb2c3c730c03edfd9dc10cb55a7de3498dd81"},
+    {url = "https://files.pythonhosted.org/packages/ba/60/8ac601523f166d7f9a577c8f06d101a6fbefa65c7a5902313e1e4509e376/platformdirs-3.5.2-py3-none-any.whl", hash = "sha256:bfb917aff291e8587ac2c8c44d8ed1b14a775a250a4ed61935f34de4840c1ce8"},
 ]
 "pluggy 1.0.0" = [
     {url = "https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},

--- a/{{ cookiecutter.project_name }}/webapp/production.Dockerfile
+++ b/{{ cookiecutter.project_name }}/webapp/production.Dockerfile
@@ -1,6 +1,6 @@
 FROM {{ cookiecutter.project_name }}_webapp:dev as builder
 
-FROM python:3.11.3-alpine3.17
+FROM python:3.11.4-alpine3.17
 
 COPY --from=builder /app /app
 

--- a/{{ cookiecutter.project_name }}/webapp/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/webapp/pyproject.toml
@@ -6,11 +6,11 @@ authors = [
     {name = "Michal Nakoneczny", email = "michal@nakoneczny.pl"},
 ]
 dependencies = [
-    "django==4.2.1",
-    "celery==5.2.7",
+    "django==4.2.2",
+    "celery==5.3.0",
     "django-celery-beat==2.5.0",
     "gunicorn==20.1.0",
-    "kombu==5.2.4",
+    "kombu==5.3.0",
     "psycopg2==2.9.6",
     "redis==4.5.5",
 ]


### PR DESCRIPTION
Update dependencies:
* Python from 3.11.3 to 3.11.4
* Django from 4.2.1 to 4.2.2
* celery from 5.2.7 to 5.3.0
* kombu from 5.2.4 to 5.3.0