### PR TITLE
Update: Docker, Postgres, and Redis images; postgresql-client sys deps; pip, pdm, gunicorn python deps

### DIFF
--- a/{{ cookiecutter.project_name }}/docker-compose.yml
+++ b/{{ cookiecutter.project_name }}/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   db:
-    image: "postgres:15.2-alpine3.17"
+    image: "postgres:15.3-alpine3.18"
     restart: "on-failure"
     environment:
       POSTGRES_HOST: "${POSTGRES_HOST}"
@@ -17,7 +17,7 @@ services:
       retries: 4
 
   redis:
-    image: "redis:7.0.10-alpine3.17"
+    image: "redis:7.0.12-alpine3.18"
     command: >
       --requirepass ${REDIS_PASSWORD}
     restart: "on-failure"

--- a/{{ cookiecutter.project_name }}/webapp/Dockerfile
+++ b/{{ cookiecutter.project_name }}/webapp/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.11.4-slim-bullseye
+FROM python:3.11.4-slim-bookworm
 
 ARG USER_ID
 ARG GROUP_ID
 
 RUN apt-get update && \
-    apt-get install -y gcc curl ca-certificates netcat-openbsd procps postgresql-client-13 python3-dev libpq-dev
+    apt-get install -y gcc curl ca-certificates netcat-openbsd procps postgresql-client-15 python3-dev libpq-dev
 
 RUN groupadd --force --gid ${GROUP_ID} --system usergroup && \
     useradd --uid ${USER_ID} --gid ${GROUP_ID} --create-home --system user && \
@@ -14,8 +14,8 @@ RUN groupadd --force --gid ${GROUP_ID} --system usergroup && \
 USER user
 
 WORKDIR /app
-RUN python -m pip install --upgrade pip==23.1.2 && \
-    pip install --user pdm==2.7.4
+RUN python -m pip install --upgrade pip==23.2.1 && \
+    pip install --user pdm==2.8.1
 ENV PATH="/app/__pypackages__/3.11/bin:/home/user/.local/bin:${PATH}"
 
 COPY pdm.lock pyproject.toml /app/

--- a/{{ cookiecutter.project_name }}/webapp/pdm.lock
+++ b/{{ cookiecutter.project_name }}/webapp/pdm.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "click"
-version = "8.1.5"
+version = "8.1.6"
 requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
 dependencies = [
@@ -157,11 +157,11 @@ dependencies = [
 
 [[package]]
 name = "gunicorn"
-version = "20.1.0"
+version = "21.2.0"
 requires_python = ">=3.5"
 summary = "WSGI HTTP Server for UNIX"
 dependencies = [
-    "setuptools>=3.0",
+    "packaging",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ summary = "Utility library for gitignore style pattern matching of file paths."
 
 [[package]]
 name = "platformdirs"
-version = "3.8.1"
+version = "3.9.1"
 requires_python = ">=3.7"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 
@@ -289,12 +289,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "68.0.0"
-requires_python = ">=3.7"
-summary = "Easily download, build, install, upgrade, and uninstall Python packages"
-
-[[package]]
 name = "six"
 version = "1.16.0"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
@@ -333,7 +327,7 @@ summary = "Measures the displayed width of unicode strings in a terminal"
 lock_version = "4.2"
 cross_platform = true
 groups = ["default", "dev"]
-content_hash = "sha256:c4319180d7156a2f98f796d16764ce6fbfea410f36a2ebbc4d9377c488f35ae6"
+content_hash = "sha256:502203047bb6a485747e5263d334e0d07973955a1292f4d9ae3895eaeab7a181"
 
 [metadata.files]
 "amqp 5.1.1" = [
@@ -380,9 +374,9 @@ content_hash = "sha256:c4319180d7156a2f98f796d16764ce6fbfea410f36a2ebbc4d9377c48
     {url = "https://files.pythonhosted.org/packages/18/b9/cb8d519ea0094b9b8fe7480225c14937517729f8ec927643dc7379904f64/celery-5.3.1-py3-none-any.whl", hash = "sha256:27f8f3f3b58de6e0ab4f174791383bbd7445aff0471a43e99cfd77727940753f"},
     {url = "https://files.pythonhosted.org/packages/a4/e2/102f8d3453a9f1c6918245a97b9b8e7352a2925d4c5477a7401de2bb54dc/celery-5.3.1.tar.gz", hash = "sha256:f84d1c21a1520c116c2b7d26593926581191435a03aa74b77c941b93ca1c6210"},
 ]
-"click 8.1.5" = [
-    {url = "https://files.pythonhosted.org/packages/22/b3/1da4ea0efa2e5ae410a347be614162ca08bd24a84059938aa5122d1e751b/click-8.1.5-py3-none-any.whl", hash = "sha256:e576aa487d679441d7d30abb87e1b43d24fc53bffb8758443b1a9e1cee504548"},
-    {url = "https://files.pythonhosted.org/packages/7e/ad/7a6a96fab480fb2fbf52f782b2deb3abe1d2c81eca3ef68a575b5a6a4f2e/click-8.1.5.tar.gz", hash = "sha256:4be4b1af8d665c6d942909916d31a213a106800c47d0eeba73d34da3cbc11367"},
+"click 8.1.6" = [
+    {url = "https://files.pythonhosted.org/packages/1a/70/e63223f8116931d365993d4a6b7ef653a4d920b41d03de7c59499962821f/click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
+    {url = "https://files.pythonhosted.org/packages/72/bd/fedc277e7351917b6c4e0ac751853a97af261278a4c7808babafa8ef2120/click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
 ]
 "click-didyoumean 0.3.0" = [
     {url = "https://files.pythonhosted.org/packages/2f/a7/822fbc659be70dcb75a91fb91fec718b653326697d0e9907f4f90114b34f/click-didyoumean-0.3.0.tar.gz", hash = "sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"},
@@ -477,9 +471,9 @@ content_hash = "sha256:c4319180d7156a2f98f796d16764ce6fbfea410f36a2ebbc4d9377c48
     {url = "https://files.pythonhosted.org/packages/a3/ba/d8226ac6a2d285e4f2b89d05707e7f025c7642586cb00388536d841b02f7/django_timezone_field-5.1-py3-none-any.whl", hash = "sha256:16ca9955a4e16064e32168b1a0d1cdb2839679c6cb56856c1f49f506e2ca4281"},
     {url = "https://files.pythonhosted.org/packages/d5/77/26eed0dae663f46032b4dcb86a22498cc02e2357e62fff4abaaef4945c1b/django_timezone_field-5.1.tar.gz", hash = "sha256:73fc49519273cd5da1c7f16abc04a4bcad87b00cc02968d0d384c0fecf9a8a86"},
 ]
-"gunicorn 20.1.0" = [
-    {url = "https://files.pythonhosted.org/packages/28/5b/0d1f0296485a6af03366604142ea8f19f0833894db3512a40ed07b2a56dd/gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
-    {url = "https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
+"gunicorn 21.2.0" = [
+    {url = "https://files.pythonhosted.org/packages/06/89/acd9879fa6a5309b4bf16a5a8855f1e58f26d38e0c18ede9b3a70996b021/gunicorn-21.2.0.tar.gz", hash = "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"},
+    {url = "https://files.pythonhosted.org/packages/0e/2a/c3a878eccb100ccddf45c50b6b8db8cf3301a6adede6e31d48e8531cab13/gunicorn-21.2.0-py3-none-any.whl", hash = "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0"},
 ]
 "iniconfig 2.0.0" = [
     {url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
@@ -529,9 +523,9 @@ content_hash = "sha256:c4319180d7156a2f98f796d16764ce6fbfea410f36a2ebbc4d9377c48
     {url = "https://files.pythonhosted.org/packages/95/60/d93628975242cc515ab2b8f5b2fc831d8be2eff32f5a1be4776d49305d13/pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
     {url = "https://files.pythonhosted.org/packages/be/c8/551a803a6ebb174ec1c124e68b449b98a0961f0b737def601e3c1fbb4cfd/pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
 ]
-"platformdirs 3.8.1" = [
-    {url = "https://files.pythonhosted.org/packages/92/38/3dd18a282991c004851ea1f0953105a186cfc691eee2792778ac2ca060f8/platformdirs-3.8.1.tar.gz", hash = "sha256:f87ca4fcff7d2b0f81c6a748a77973d7af0f4d526f98f308477c3c436c74d528"},
-    {url = "https://files.pythonhosted.org/packages/9e/d8/563a9fc17153c588c8c2042d2f0f84a89057cdb1c30270f589c88b42d62c/platformdirs-3.8.1-py3-none-any.whl", hash = "sha256:cec7b889196b9144d088e4c57d9ceef7374f6c39694ad1577a0aab50d27ea28c"},
+"platformdirs 3.9.1" = [
+    {url = "https://files.pythonhosted.org/packages/6d/a7/47b7088a28c8fe5775eb15281bf44d39facdbe4bc011a95ccb89390c2db9/platformdirs-3.9.1-py3-none-any.whl", hash = "sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f"},
+    {url = "https://files.pythonhosted.org/packages/a1/70/c1d14c0c58d975f06a449a403fac69d3c9c6e8ae2a529f387d77c29c2e56/platformdirs-3.9.1.tar.gz", hash = "sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421"},
 ]
 "pluggy 1.2.0" = [
     {url = "https://files.pythonhosted.org/packages/51/32/4a79112b8b87b21450b066e102d6608907f4c885ed7b04c3fdb085d4d6ae/pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
@@ -579,10 +573,6 @@ content_hash = "sha256:c4319180d7156a2f98f796d16764ce6fbfea410f36a2ebbc4d9377c48
 "redis 4.6.0" = [
     {url = "https://files.pythonhosted.org/packages/20/2e/409703d645363352a20c944f5d119bdae3eb3034051a53724a7c5fee12b8/redis-4.6.0-py3-none-any.whl", hash = "sha256:e2b03db868160ee4591de3cb90d40ebb50a90dd302138775937f6a42b7ed183c"},
     {url = "https://files.pythonhosted.org/packages/73/88/63d802c2b18dd9eaa5b846cbf18917c6b2882f20efda398cc16a7500b02c/redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d"},
-]
-"setuptools 68.0.0" = [
-    {url = "https://files.pythonhosted.org/packages/c7/42/be1c7bbdd83e1bfb160c94b9cafd8e25efc7400346cf7ccdbdb452c467fa/setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
-    {url = "https://files.pythonhosted.org/packages/dc/98/5f896af066c128669229ff1aa81553ac14cfb3e5e74b6b44594132b8540e/setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
 ]
 "six 1.16.0" = [
     {url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/{{ cookiecutter.project_name }}/webapp/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/webapp/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "django==4.2.3",
     "celery==5.3.1",
     "django-celery-beat==2.5.0",
-    "gunicorn==20.1.0",
+    "gunicorn==21.2.0",
     "kombu==5.3.1",
     "psycopg2==2.9.6",
     "redis==4.6.0",


### PR DESCRIPTION
Update Docker images:
* python from 3.11.4 slim-bullseye to slim-bookworm
* postgres from 15.2 alpine 3.17 to 15.3 alpine 3.18
* redis 7.0.10 alpine 3.17 to 7.0.12 alpine 3.18

Update system packages:
* postgresql-client-13 to postgresql-client-15

Update dependencies:
* pip from 23.1.2 to 23.2.1
* pdm from 2.7.4 to 2.8.1
* gunicorn from 20.1.0 to 21.2.0