### PR TITLE
Bugfix: Fix dependabot error on  `#/updates/0/schedule/time`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
     schedule:
       interval: weekly
       day: friday
-      time: 18:00
+      time: "18:00"
       timezone: Asia/Tokyo


### PR DESCRIPTION
dependabot.yml validation failed after merging to main (https://github.com/mnako/cookiecutter-django-postgres-redis-celery/runs/17486383390) with error

```
The property '#/updates/0/schedule/time' of type integer did not match the following type: string
```

Looks like Dependabot is _not_ using YAML 1.2 and interpreting `18:00` as a base-60 integer.

All the more reasons to add a strict YAML linter, but for now let me just quote the time.